### PR TITLE
Policy.json should be defined by user

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,10 @@ provisioner:
   formula: ceilometer
   grains:
     noservices: True
+  dependencies:
+    - name: keystone
+      repo: git
+      source: https://github.com/salt-formulas/salt-formula-keystone
   state_top:
     base:
       "*":

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,18 @@ Ceilometer API/controller node
           password: pwd
           virtual_host: '/openstack'
 
+Configuration of policy.json file
+
+.. code-block:: yaml
+
+    ceilometer:
+      server:
+        ....
+        policy:
+          segregation: 'rule:context_is_admin'
+          # Add key without value to remove line from policy.json
+          'telemetry:get_resource':
+
 Databases configuration
 
 MongoDB example:

--- a/ceilometer/server.sls
+++ b/ceilometer/server.sls
@@ -12,6 +12,30 @@ ceilometer_server_packages:
   - require:
     - pkg: ceilometer_server_packages
 
+{%- for name, rule in server.get('policy', {}).iteritems() %}
+
+{%- if rule != None %}
+rule_{{ name }}_present:
+  keystone_policy.rule_present:
+  - path: /etc/ceilometer/policy.json
+  - name: {{ name }}
+  - rule: {{ rule }}
+  - require:
+    - pkg: ceilometer_server_packages
+
+{%- else %}
+
+rule_{{ name }}_absent:
+  keystone_policy.rule_absent:
+  - path: /etc/ceilometer/policy.json
+  - name: {{ name }}
+  - require:
+    - pkg: ceilometer_server_packages
+
+{%- endif %}
+
+{%- endfor %}
+
 {%- for publisher_name, publisher in server.get('publisher', {}).iteritems() %}
 
 {%- if publisher_name != "default" %}

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,3 +1,6 @@
 name: "ceilometer"
 version: "2016.4.1"
 source: "https://github.com/openstack/salt-formula-ceilometer"
+dependencies:
+  - name: keystone
+    source: "https://github.com/salt-formulas/salt-formula-keystone"

--- a/tests/pillar/server_cluster.sls
+++ b/tests/pillar/server_cluster.sls
@@ -51,3 +51,6 @@ ceilometer:
         enabled: true
         host: 127.0.0.1
         port: 8086
+      policy:
+        segregation: 'rule:context_is_admin'
+        'telemetry:get_resource':

--- a/tests/pillar/server_single.sls
+++ b/tests/pillar/server_single.sls
@@ -41,3 +41,6 @@ ceilometer:
         enabled: true
         host: 127.0.0.1
         port: 8086
+      policy:
+        segregation: 'rule:context_is_admin'
+        'telemetry:get_resource':


### PR DESCRIPTION
User can override and add values to policy.json by creating flat
key-value structure under ceilometer:server:policy.

Change-Id: Ifeb2dbf54b0e32eb10a58f853a05fabf930a55a4