### PR TITLE
Make some options for ceilometer-agent-central configurable.

### DIFF
--- a/ceilometer/files/mitaka/ceilometer-server.conf.Debian
+++ b/ceilometer/files/mitaka/ceilometer-server.conf.Debian
@@ -86,6 +86,20 @@ rpc_backend = rabbit
 # option. (string value)
 #control_exchange = openstack
 
+# List of pollsters (or wildcard templates) to be used while polling
+#pollster_list =
+{%- if server.pollster_list is defined %}
+pollster_list = {{ server.pollster_list }}
+{%- endif %}
+
+# To reduce polling agent load, samples are sent to the notification
+# agent in a batch. To gain higher throughput at the cost of load set
+# this to False.
+#batch_polled_samples = True
+{%- if server.batch_polled_samples is defined %}
+batch_polled_samples = {{ server.batch_polled_samples|lower }}
+{%- endif %}
+
 [alarm]
 
 #

--- a/ceilometer/files/newton/ceilometer-server.conf.Debian
+++ b/ceilometer/files/newton/ceilometer-server.conf.Debian
@@ -222,6 +222,19 @@ rpc_backend = rabbit
 # value means endless wait. (integer value)
 #graceful_shutdown_timeout = 60
 
+# List of pollsters (or wildcard templates) to be used while polling
+#pollster_list =
+{%- if server.pollster_list is defined %}
+pollster_list = {{ server.pollster_list }}
+{%- endif %}
+
+# To reduce polling agent load, samples are sent to the notification
+# agent in a batch. To gain higher throughput at the cost of load set
+# this to False.
+#batch_polled_samples = True
+{%- if server.batch_polled_samples is defined %}
+batch_polled_samples = {{ server.batch_polled_samples|lower }}
+{%- endif %}
 
 [cors]
 

--- a/ceilometer/files/ocata/ceilometer-server.conf.Debian
+++ b/ceilometer/files/ocata/ceilometer-server.conf.Debian
@@ -474,6 +474,19 @@ transport_url = rabbit://{{ server.message_queue.user }}:{{ server.message_queue
 # value means endless wait. (integer value)
 #graceful_shutdown_timeout = 60
 
+# List of pollsters (or wildcard templates) to be used while polling
+#pollster_list =
+{%- if server.pollster_list is defined %}
+pollster_list = {{ server.pollster_list }}
+{%- endif %}
+
+# To reduce polling agent load, samples are sent to the notification
+# agent in a batch. To gain higher throughput at the cost of load set
+# this to False.
+#batch_polled_samples = True
+{%- if server.batch_polled_samples is defined %}
+batch_polled_samples = {{ server.batch_polled_samples|lower }}
+{%- endif %}
 
 [api]
 


### PR DESCRIPTION
Needed the pollster_list, because when using OpenContrail, the neutron lbaas pollster does not work and only generates a lot of errors in the log.
I need to be able to disable batch_polled_samples because batched samples that are too big, are discarded by the ceilometer-collector, when using heka/stacklight.